### PR TITLE
Use Laurent polynomials from poly-0.4

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -26,7 +26,7 @@ exampleRndParams = RandomParams
   , pAlpha = 4
   }
 
-runProver :: IO (Proof Fr, RndOracle Fr)
+runProver :: IO (Proof, RndOracle)
 runProver = do
   let (arithCircuit, assignment) = arithCircuitExample1 exampleX exampleZ
       srs = SRS.new (exampleD (length $ aL assignment)) (pX exampleRndParams) (pAlpha exampleRndParams)
@@ -46,5 +46,5 @@ sonic (arithCircuit, assignment) = bgroup "Sonic"
   , env runProver $ \(~(proof, rndOracle@RndOracle{..})) ->
       bench "Verifier" $
       let srs = SRS.new (exampleD (length $ aL assignment)) (pX exampleRndParams) (pAlpha exampleRndParams)
-      in nf (verify srs arithCircuit proof rndOracleY rndOracleZ) rndOracleYs
+      in nf (verify srs arithCircuit proof rndOracleY rndOracleZ) rndOracleYZs
   ]

--- a/cabal.project
+++ b/cabal.project
@@ -9,3 +9,5 @@ source-repository-package
   type:     git
   location: https://github.com/adjoint-io/galois-field.git
   tag:      b59ecd8e7b8f563d13f598534fccb838b5a22dfc
+
+allow-newer: galois-field:poly

--- a/cabal.project
+++ b/cabal.project
@@ -2,5 +2,10 @@ packages: .
 
 source-repository-package
   type:     git
-  location: https://github.com/adjoint-io/poly
-  tag:      b75b853025ea75ba64f62f39d4524832f0117e36
+  location: https://github.com/Bodigrim/poly
+  tag:      0ef404be5deed9fa71507fa3e3be72a22f2958d4
+
+source-repository-package
+  type:     git
+  location: https://github.com/adjoint-io/galois-field.git
+  tag:      b59ecd8e7b8f563d13f598534fccb838b5a22dfc

--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,7 @@ dependencies:
   - galois-field    >=1.0      && <1.1
   - MonadRandom     >=0.5.1.1  && <0.6
   - pairing         >= 1.0     && <1.1
-  - poly            >= 0.3     && <0.4
+  - poly            >= 0.4     && <0.5
   - protolude       >=0.2.3    && <0.3
   - semirings       >=0.5.1    && <0.6
   - vector          >=0.12.0.0 && <0.13

--- a/sonic.cabal
+++ b/sonic.cabal
@@ -62,7 +62,7 @@ library
     , galois-field    >=1.0      && <1.1
     , MonadRandom     >=0.5.1.1  && <0.6
     , pairing         >=1.0      && <1.1
-    , poly            >=0.3      && <0.4
+    , poly            >=0.4      && <0.5
     , protolude       >=0.2.3    && <0.3
     , semirings       >=0.5.1    && <0.6
     , vector          >=0.12.0.0 && <0.13
@@ -96,7 +96,7 @@ executable sonic-example
     , galois-field      >=1.0      && <1.1
     , MonadRandom       >=0.5.1.1  && <0.6
     , pairing           >=1.0      && <1.1
-    , poly              >=0.3      && <0.4
+    , poly              >=0.4      && <0.5
     , protolude         >=0.2.3    && <0.3
     , QuickCheck        >=2.12.0   && <2.14
     , semirings         >=0.5.1    && <0.6
@@ -143,7 +143,7 @@ test-suite sonic-test
     , galois-field      >=1.0      && <1.1
     , MonadRandom       >=0.5.1.1  && <0.6
     , pairing           >=1.0      && <1.1
-    , poly              >=0.3      && <0.4
+    , poly              >=0.4      && <0.5
     , protolude         >=0.2.3    && <0.3
     , QuickCheck        >=2.12.0   && <2.14
     , semirings         >=0.5.1    && <0.6
@@ -184,7 +184,7 @@ benchmark sonic-benchmarks
     , galois-field      >=1.0      && <1.1
     , MonadRandom       >=0.5.1.1  && <0.6
     , pairing           >=1.0      && <1.1
-    , poly              >=0.3      && <0.4
+    , poly              >=0.4      && <0.5
     , protolude         >=0.2.3    && <0.3
     , QuickCheck        >=2.12.0   && <2.14
     , semirings         >=0.5.1    && <0.6

--- a/src/Sonic/Constraints.hs
+++ b/src/Sonic/Constraints.hs
@@ -9,41 +9,42 @@ module Sonic.Constraints
   , kPoly
   ) where
 
-import Protolude hiding (head)
+import Protolude hiding (head, Semiring)
 import Bulletproofs.ArithmeticCircuit (Assignment(..), GateWeights(..))
 import Data.List (zipWith4, head, (!!))
 import Data.Pairing.BLS12381 (Fr)
-import Data.Poly.Laurent (VPoly, monomial, toPoly)
-import qualified Data.Vector as V
+import Data.Poly.Sparse.Laurent (VLaurent, monomial)
+import Data.Semiring (Semiring)
+import qualified GHC.Exts
 
-import Sonic.Utils (BiVPoly, fromX, fromY, evalY)
+import Sonic.Utils (BiVLaurent, fromX, fromY, evalY)
 
 -- r(X,Y) = \sum_{i=1}^n (a_i X^i Y^i + b_i X^{-i} Y^{-i} + c_i X^{-i-n} Y^{-i-n})
 rPoly
-  :: (Eq f, Num f)
+  :: (Eq f, Semiring f)
   => Assignment f
-  -> BiVPoly f
+  -> BiVLaurent f
 rPoly Assignment{..} =
-  toPoly . V.fromList $ concat (zipWith4 f aL aR aO [1..])
+  GHC.Exts.fromList $ concat (zipWith4 f aL aR aO [1..])
   where
     f ai bi ci i = [(i, monomial i ai), (-i, monomial (-i) bi), (-i - n, monomial (-i - n) ci)]
     n = length aL
 
 -- s(X,Y) = \sum_{i=1}^n (u_i(Y)X^{-i} + v_i(Y)X^i + w_i(Y)X^{i+n})
 sPoly
-  :: forall f. (Eq f, Num f)
+  :: forall f. (Eq f, Num f, Semiring f)
   => GateWeights f
-  -> BiVPoly f
+  -> BiVLaurent f
 sPoly GateWeights{..}
-  = toPoly . V.fromList . concat $
+  = GHC.Exts.fromList . concat $
     (\i -> [(-i, uiY i), (i, viY i), (i + n, wiY i)]) <$> [1..n]
   where
-    uiY, viY, wiY :: Int -> VPoly f
+    uiY, viY, wiY :: Int -> VLaurent f
     uiY i = xiY i wL  -- u_i(Y) = \sum_{q=1}^Q (Y^{q+n} u_{q,i})
     viY i = xiY i wR  -- v_i(Y) = \sum_{q=1}^Q (Y^{q+n} v_{q,i}
     wiY i = monomial (-i) (-1) + monomial i (-1) + xiY i wO -- w_i(Y) = -Y^{i} - Y^{-i} + \sum_{q=1}^Q (Y^{q+n} u_{q,i}
 
-    xiY :: Int -> [[f]] -> VPoly f
+    xiY :: Int -> [[f]] -> VLaurent f
     xiY i xL = foldl' (fxqi i) 0 (zip [1..] xL)
     fxqi i acc (q, xLq) = acc + monomial (q + n) (xLq !! (i - 1))
 
@@ -53,15 +54,15 @@ sPoly GateWeights{..}
 
 -- t(X,Y) = r(X, 1)(r(X,Y) + s(X, Y)) - k(Y)
 tPoly
-  :: BiVPoly Fr
-  -> BiVPoly Fr
-  -> VPoly Fr
-  -> BiVPoly Fr
+  :: BiVLaurent Fr
+  -> BiVLaurent Fr
+  -> VLaurent Fr
+  -> BiVLaurent Fr
 tPoly rXY sXY kY = (rX1 * rXY') + k1Y
   where
     rXY' = rXY + sXY
     rX1 = fromX $ evalY 1 rXY
     k1Y = fromY $ negate kY
 
-kPoly :: [Fr] -> Int -> VPoly Fr
-kPoly k n = toPoly . V.fromList $ zip [n+1..] k
+kPoly :: [Fr] -> Int -> VLaurent Fr
+kPoly k n = GHC.Exts.fromList $ zip [n+1..] k

--- a/src/Sonic/Signature.hs
+++ b/src/Sonic/Signature.hs
@@ -14,8 +14,8 @@ import Control.Monad.Random (MonadRandom)
 import Data.Field.Galois (rnd)
 import Data.List (zip3)
 import Data.Pairing.BLS12381 (Fr, G1, BLS12381)
-import Data.Poly.Laurent (eval)
-import Sonic.Utils (BiVPoly, evalX, evalY)
+import Data.Poly.Sparse.Laurent (eval)
+import Sonic.Utils (BiVLaurent, evalX, evalY)
 import Sonic.CommitmentScheme (commitPoly, openPoly, pcV)
 import Sonic.SRS (SRS(..))
 
@@ -32,7 +32,7 @@ data HscProof = HscProof
 hscProve
   :: (MonadRandom m)
   => SRS               -- srs
-  -> BiVPoly Fr        -- S(X,Y)
+  -> BiVLaurent Fr     -- S(X,Y)
   -> [(Fr, Fr)]        -- {(y_j, z_j)}_{j=1}^m
   -> m HscProof
 hscProve srs@SRS{..} sXY yzs = do
@@ -73,7 +73,7 @@ hscProve srs@SRS{..} sXY yzs = do
 
 hscVerify
   :: SRS
-  -> BiVPoly Fr        -- S(X,Y)
+  -> BiVLaurent Fr     -- S(X,Y)
   -> [(Fr, Fr)]        -- {(y_j, z_j)}_{j=1}^m
   -> HscProof
   -> Bool

--- a/src/Sonic/Utils.hs
+++ b/src/Sonic/Utils.hs
@@ -1,5 +1,5 @@
 module Sonic.Utils
-  ( BiVPoly
+  ( BiVLaurent
   , evalX
   , evalY
   , fromX
@@ -7,20 +7,21 @@ module Sonic.Utils
   ) where
 
 import Protolude
-import Data.Poly.Laurent (VPoly, eval, monomial, scale, toPoly, unPoly)
+import Data.Poly.Sparse (toPoly, unPoly)
+import Data.Poly.Sparse.Laurent (VLaurent, eval, monomial, scale, unLaurent, toLaurent)
 import Data.Field.Galois (GaloisField(..), pow)
+import qualified GHC.Exts
 
-type BiVPoly k = VPoly (VPoly k)
+type BiVLaurent k = VLaurent (VLaurent k)
 
-evalX :: GaloisField k => k -> BiVPoly k -> VPoly k
-evalX x = sum . (<$>) (uncurry (scale 0 . pow x . fromIntegral)) . unPoly
+evalX :: GaloisField k => k -> BiVLaurent k -> VLaurent k
+evalX x = sum . fmap (uncurry (scale 0 . pow x . fromIntegral)) . GHC.Exts.toList
 
-evalY :: GaloisField k => k -> BiVPoly k -> VPoly k
-evalY x = toPoly . ((<$>) . (<$>) . flip eval) x . unPoly
+evalY :: GaloisField k => k -> BiVLaurent k -> VLaurent k
+evalY x = uncurry toLaurent . fmap (toPoly . ((<$>) . (<$>) . flip eval) x . unPoly) . unLaurent
 
--- toPoly $ (<$>) (monomial 0) <$> unPoly p
-fromX :: GaloisField k => VPoly k -> BiVPoly k
-fromX = toPoly . ((<$>) . (<$>) . monomial) 0 . unPoly
+fromX :: GaloisField k => VLaurent k -> BiVLaurent k
+fromX = uncurry toLaurent . fmap (toPoly . ((<$>) . (<$>) . monomial) 0 . unPoly) . unLaurent
 
-fromY :: GaloisField k => VPoly k -> BiVPoly k
+fromY :: GaloisField k => VLaurent k -> BiVLaurent k
 fromY = monomial 0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,10 +2,15 @@ resolver: lts-13.23
 packages:
   - .
 extra-deps:
-  - git: https://github.com/adjoint-io/poly.git
-    commit: b75b853025ea75ba64f62f39d4524832f0117e36
+  - git: https://github.com/Bodigrim/poly.git
+    commit: 0ef404be5deed9fa71507fa3e3be72a22f2958d4
+  - git: https://github.com/adjoint-io/galois-field.git
+    commit: b59ecd8e7b8f563d13f598534fccb838b5a22dfc
   - elliptic-curve-0.3.0
-  - galois-field-1.0.0
   - pairing-1.0.0
-  - semirings-0.5.1
   - bulletproofs-1.1.0
+  - bitvec-1.0.3.0
+  - mod-0.1.1.0
+  - semirings-0.5.3
+  - vector-algorithms-0.8.0.3
+allow-newer: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,18 +6,32 @@
 packages:
 - completed:
     cabal-file:
-      size: 2085
-      sha256: d4bef2a796a5567b888e568e8c3117e4c2f5d1108b803ec46bd7804d593ab869
+      size: 2127
+      sha256: d5991cbab04deb6792d35190fc2ecb213a8b4544f0bd3e6c99eec2b4b483afc2
     name: poly
-    version: 0.3.2.0
-    git: https://github.com/adjoint-io/poly.git
+    version: 0.4.0.0
+    git: https://github.com/Bodigrim/poly.git
     pantry-tree:
-      size: 2109
-      sha256: 05ebc44a9cc5ecda047aa0179020615941ae5b698586854d121b4219ec3cc114
-    commit: b75b853025ea75ba64f62f39d4524832f0117e36
+      size: 1999
+      sha256: 785b25407fcae95c8d22ee8baaa2e05f989f106a90fea377f2ff2cf385ae9909
+    commit: 0ef404be5deed9fa71507fa3e3be72a22f2958d4
   original:
-    git: https://github.com/adjoint-io/poly.git
-    commit: b75b853025ea75ba64f62f39d4524832f0117e36
+    git: https://github.com/Bodigrim/poly.git
+    commit: 0ef404be5deed9fa71507fa3e3be72a22f2958d4
+- completed:
+    cabal-file:
+      size: 4679
+      sha256: 2f3157954320d032020493e584a4a4f8b1a2c529e8ce40c374eb0ab45706b0ac
+    name: galois-field
+    version: 1.0.1
+    git: https://github.com/adjoint-io/galois-field.git
+    pantry-tree:
+      size: 4578
+      sha256: 2d8b08079f3a9a30272cd853d97b1ef5458a05213d51e21bc36c28ac40e995f8
+    commit: b59ecd8e7b8f563d13f598534fccb838b5a22dfc
+  original:
+    git: https://github.com/adjoint-io/galois-field.git
+    commit: b59ecd8e7b8f563d13f598534fccb838b5a22dfc
 - completed:
     hackage: elliptic-curve-0.3.0@sha256:7d314ff56011de62370bdd1b840866d1e5ce061972e54be673f5768cbf8d3d42,7072
     pantry-tree:
@@ -26,13 +40,6 @@ packages:
   original:
     hackage: elliptic-curve-0.3.0
 - completed:
-    hackage: galois-field-1.0.0@sha256:d44007898c07a6c913a38f78e7246c7785ae3052ca55ad713783345d06a28419,3470
-    pantry-tree:
-      size: 1444
-      sha256: 1b265e1c3062a06a48a535c1681a954c26bee5959a42e97fc0e4fd8b5a90849f
-  original:
-    hackage: galois-field-1.0.0
-- completed:
     hackage: pairing-1.0.0@sha256:709d2e1a98b18327d2fba4efaa6069ef783333c95055ad73416e9401d02000ac,3507
     pantry-tree:
       size: 1693
@@ -40,19 +47,40 @@ packages:
   original:
     hackage: pairing-1.0.0
 - completed:
-    hackage: semirings-0.5.1@sha256:597e4070dcb75c3e347566114e140ba343843f80f3e16a456bb2e9e9d1d09430,3743
-    pantry-tree:
-      size: 610
-      sha256: cc4e01176f1a56c97dc923416a6939dcdc004584cccf8a2b1c67bd156b31179a
-  original:
-    hackage: semirings-0.5.1
-- completed:
     hackage: bulletproofs-1.1.0@sha256:866a6543e13fd0ba7b237140ee4fa9cf54eb00ee077472f33acb3490d13f7835,5127
     pantry-tree:
       size: 2191
       sha256: 90f49d9073b529790645f00c6db1eb2939b33e380bca21d0f030da1027a192f5
   original:
     hackage: bulletproofs-1.1.0
+- completed:
+    hackage: bitvec-1.0.3.0@sha256:f69ed0e463045cb497a7cf1bc808a2e84ea0ce286cf9507983bb6ed8b4bd3993,3977
+    pantry-tree:
+      size: 2372
+      sha256: e3cf4b28e01c3eb9b0cf46a8a2e7eef1ced133d5ad626aaba099cf468007dd90
+  original:
+    hackage: bitvec-1.0.3.0
+- completed:
+    hackage: mod-0.1.1.0@sha256:57f230d5664b1c311d1044c259ef880875e4b3bcbfc7c57eab3bf03fce87f445,1838
+    pantry-tree:
+      size: 464
+      sha256: ca61450dd1d84e6beefba010a7032dfb5a8bc2e8344a369430992c56ec083ad7
+  original:
+    hackage: mod-0.1.1.0
+- completed:
+    hackage: semirings-0.5.3@sha256:4b0d243f88bb07c0673978a37b6b9fd16da44f15e8d552fb08795d9a88a3dc76,3791
+    pantry-tree:
+      size: 610
+      sha256: 0bc3f63a3b92be1c6be2e36c7db8df62e61b2860eba7f083b84e2b16dbaa2d69
+  original:
+    hackage: semirings-0.5.3
+- completed:
+    hackage: vector-algorithms-0.8.0.3@sha256:477ef5ac82fdd28a39536ed0a767faec3425802827abee485be31db5bc6f5e90,3488
+    pantry-tree:
+      size: 1439
+      sha256: 9f04ef44c2459a122f2d5c093b4a9ebc47aaa00284a7bff9793fee7c6783f979
+  original:
+    hackage: vector-algorithms-0.8.0.3
 snapshots:
 - completed:
     size: 498398

--- a/test/Test/CommitmentScheme.hs
+++ b/test/Test/CommitmentScheme.hs
@@ -7,8 +7,8 @@ import Bulletproofs.ArithmeticCircuit
 import Control.Monad.Random (MonadRandom)
 import Data.Field.Galois (rnd)
 import Data.Pairing.BLS12381
-import Data.Poly.Laurent (eval, toPoly, monomial)
-import qualified Data.Vector as V
+import Data.Poly.Sparse.Laurent (eval, monomial)
+import qualified GHC.Exts
 import Test.Tasty
 import Test.Tasty.QuickCheck hiding (scale)
 import qualified Test.QuickCheck.Monadic as QCM
@@ -86,8 +86,8 @@ test_rX1YZ_commit_scheme = localOption (QuickCheckTests 50) $
       let srs = SRS.new d pX pAlpha
       cns <- lift $ replicateM 4 rnd
       let rXY = rPoly assignment
-          sumcXY :: BiVPoly Fr
-          sumcXY = toPoly . V.fromList $
+          sumcXY :: BiVLaurent Fr
+          sumcXY = GHC.Exts.fromList $
             zipWith (\i cni -> (negate (2 * n + i), monomial (negate (2 * n + i)) cni)) [1..] cns
           polyR' = rXY + sumcXY
           commitment = commitPoly srs (fromIntegral n) (evalY 1 polyR')

--- a/test/Test/Constraints.hs
+++ b/test/Test/Constraints.hs
@@ -7,7 +7,7 @@ import Control.Monad.Random (MonadRandom)
 import Data.Field.Galois (rnd)
 import Data.List ((!!))
 import Data.Pairing.BLS12381
-import Data.Poly.Laurent (eval)
+import Data.Poly.Sparse.Laurent (eval)
 import Test.Tasty.QuickCheck
 import qualified Test.QuickCheck.Monadic as QCM
 

--- a/test/Test/Reference.hs
+++ b/test/Test/Reference.hs
@@ -93,8 +93,10 @@ arithCircuitExample2 x z =
 -- "...in our polynomial constraint system 3n < d
 -- (otherwise we cannot commit to t(X,Y)),
 -- thus r(X,Y) has no (−d + n) term."
+--
+-- Moreover, 'Sonic.Protocol.prove' requires d >= 7n.
 randomD :: MonadRandom m => Int -> m Int
-randomD n = getRandomR (3 * n + 9, 100 * n)
+randomD n = getRandomR (7 * n, 100 * n)
 
 data RandomParams = RandomParams
   { pX :: Fr

--- a/test/Test/Reference.hs
+++ b/test/Test/Reference.hs
@@ -1,18 +1,19 @@
 {-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
 module Test.Reference where
 
-import Protolude
+import Protolude hiding (Semiring)
 import Bulletproofs.ArithmeticCircuit (ArithCircuit(..), Assignment(..), GateWeights(..))
 import Control.Monad.Random (MonadRandom, getRandomR)
 import Data.Field.Galois (rnd)
 import Data.Pairing.BLS12381 (Fr)
-import Data.Poly.Laurent (VPoly, unPoly)
-import qualified Data.Vector as V
+import Data.Poly.Sparse.Laurent (VLaurent)
+import Data.Semiring (Semiring)
+import qualified GHC.Exts
 
 import Test.QuickCheck
 
-getZeroCoeff :: VPoly f -> Maybe f
-getZeroCoeff p = case filter ((==) 0 . fst) . V.toList . unPoly $ p of
+getZeroCoeff :: (Eq f, Semiring f) => VLaurent f -> Maybe f
+getZeroCoeff p = case filter ((==) 0 . fst) . GHC.Exts.toList $ p of
   [] -> Nothing
   [(_, z)] -> Just z
   _ -> panic "Impossibly many zero coefficients"

--- a/test/Test/Reference.hs
+++ b/test/Test/Reference.hs
@@ -95,7 +95,12 @@ arithCircuitExample2 x z =
 -- thus r(X,Y) has no (−d + n) term."
 --
 -- Moreover, 'Sonic.Protocol.prove' requires d >= 7n.
+-- Further, the existing implementation of
+-- 'Sonic.CommitmentScheme.{commit,open}Poly'
+-- for some reason requires d >= 12 for n = 1 and d >= 16 for n = 2.
 randomD :: MonadRandom m => Int -> m Int
+randomD 1 = getRandomR (12, 100)
+randomD 2 = getRandomR (16, 200)
 randomD n = getRandomR (7 * n, 100 * n)
 
 data RandomParams = RandomParams


### PR DESCRIPTION
Laurent polynomials have landed into `poly` and will shortly be released as `poly-0.4`. This PR migrates `sonic` from https://github.com/adjoint-io/poly.git to https://github.com/Bodigrim/poly.git, reflecting changes of API. Note that `adjoint-io/poly` fork used a sparse representation to implement Laurent polynomials, which corresponds to `Data.Poly.Sparse.Laurent` in `Bodigrim/poly`.

Both before and after these changes the test suite intermittently fails, so there is no further regression.

```
  Test
    Protocol
      Sonic protocol:                 FAIL (722.53s)
        *** Failed! Exception: 'FatalError {fatalErrorMessage = "Parameter d is not large enough: 70 should be greater than 98"}' (after 47 tests):
        Use --quickcheck-replay=752696 to reproduce.
```

----

Actually, if this looks good, I can go ahead with `poly-0.4` release and point `stack.yaml` to Hackage instead of a git commit.